### PR TITLE
s6 v3 temporary fix

### DIFF
--- a/prometheus_node_exporter/CHANGELOG.md
+++ b/prometheus_node_exporter/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.0.6] - 2022-05-17
+- Fix S6-overlay v3 problems
+- Add build.json file to better control base image versions
+- Small formatting fixes and readability changes
+
 ## [0.0.5] - 2022-02-13
 - Added HTTP Basic Auth
 

--- a/prometheus_node_exporter/Dockerfile
+++ b/prometheus_node_exporter/Dockerfile
@@ -5,8 +5,9 @@ FROM $BUILD_FROM
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Setup base system
-ARG BUILD_ARCH=amd64
-ENV NODE_EXPORTER_VERSION=1.3.1
+ARG \
+  BUILD_ARCH \
+  NODE_EXPORTER_VERSION
 
 # Copy root filesystem
 COPY rootfs /
@@ -22,8 +23,3 @@ RUN \
     && adduser -s /bin/false -D -H prometheus \
     && chown -R prometheus:prometheus /usr/local/bin/node_exporter \
     && rm -f -r /tmp/*
-
-# Build arguments
-ARG BUILD_DATE
-ARG BUILD_REF
-ARG BUILD_VERSION

--- a/prometheus_node_exporter/README.md
+++ b/prometheus_node_exporter/README.md
@@ -64,6 +64,8 @@ WIP
 - [X] Add HTTP Basic Auth
 - [ ] Add abilty to enter plain-text password instead of bcyrpt-ed hash
 - [ ] Add TLS
+- [ ] Per [this comment](https://community.home-assistant.io/t/hello-world-example-addon-from-developer-docs-stopped-working-s6-overlay-issue/421486/7), setup container images on a registry (DockerHub or GitHub) so that users aren't building the container with each install (would have prevented [this issue](https://github.com/loganmarchione/hassos-addons/issues/2))
+- [ ] Investigate CI/CD for this repo, specifically [this](https://github.com/home-assistant/actions) and [this](https://github.com/hassio-addons/addon-glances/blob/main/.github/workflows/ci.yaml) as an example
 
 ## FAQ
 

--- a/prometheus_node_exporter/README.md
+++ b/prometheus_node_exporter/README.md
@@ -66,6 +66,7 @@ WIP
 - [ ] Add TLS
 - [ ] Per [this comment](https://community.home-assistant.io/t/hello-world-example-addon-from-developer-docs-stopped-working-s6-overlay-issue/421486/7), setup container images on a registry (DockerHub or GitHub) so that users aren't building the container with each install (would have prevented [this issue](https://github.com/loganmarchione/hassos-addons/issues/2))
 - [ ] Investigate CI/CD for this repo, specifically [this](https://github.com/home-assistant/actions) and [this](https://github.com/hassio-addons/addon-glances/blob/main/.github/workflows/ci.yaml) as an example
+- [ ] Investigate dropping API access (e.g., `hassio_api`, `homeassistant_api`, `auth_api`) in order to get my rating up
 
 ## FAQ
 

--- a/prometheus_node_exporter/build.json
+++ b/prometheus_node_exporter/build.json
@@ -1,8 +1,8 @@
 {
   "build_from": {
-    "amd64": "ghcr.io/home-assistant/amd64-base:3.15",
-    "aarch64": "ghcr.io/home-assistant/aarch64-base:3.15",
-    "armv7": "ghcr.io/home-assistant/armv7-base:3.15"
+    "amd64": "ghcr.io/hassio-addons/base/amd64:11.1.0",
+    "aarch64": "ghcr.io/hassio-addons/base/aarch64:11.1.0",
+    "armv7": "ghcr.io/hassio-addons/base/armv7:11.1.0"
   },
   "args": {
     "NODE_EXPORTER_VERSION": "1.3.1"

--- a/prometheus_node_exporter/build.json
+++ b/prometheus_node_exporter/build.json
@@ -1,0 +1,10 @@
+{
+  "build_from": {
+    "amd64": "ghcr.io/home-assistant/amd64-base:3.15",
+    "aarch64": "ghcr.io/home-assistant/aarch64-base:3.15",
+    "armv7": "ghcr.io/home-assistant/armv7-base:3.15"
+  },
+  "args": {
+    "NODE_EXPORTER_VERSION": "1.3.1"
+  }
+}

--- a/prometheus_node_exporter/config.json
+++ b/prometheus_node_exporter/config.json
@@ -23,13 +23,13 @@
   "host_pid": true,
   "apparmor": false,
   "options": {
-	  "enable_basic_auth": false,
+    "enable_basic_auth": false,
     "basic_auth_user": "prom",
-	  "basic_auth_pass": "$2a$12$Azy3nrjebl.U17DLmpX57.cUUKzm/PX5thtAkf7xl/hUHSJrm4VkS"
+    "basic_auth_pass": "$2a$12$Azy3nrjebl.U17DLmpX57.cUUKzm/PX5thtAkf7xl/hUHSJrm4VkS"
   },
   "schema": {
-	  "enable_basic_auth": "bool",
+    "enable_basic_auth": "bool",
     "basic_auth_user": "str",
-	  "basic_auth_pass": "str"
+    "basic_auth_pass": "str"
   }
 }

--- a/prometheus_node_exporter/config.json
+++ b/prometheus_node_exporter/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Prometheus Node Exporter",
-  "version": "dev",
+  "version": "0.0.6",
   "slug": "prometheus_node_exporter",
   "description": "Prometheus node exporter for hardware and OS metrics",
   "url": "https://github.com/loganmarchione/hassos-addons/tree/main/prometheus_node_exporter",
@@ -8,8 +8,6 @@
   "startup": "services",
   "boot": "auto",
   "init": false,
-  "options": {},
-  "schema": {},
   "webui": "http://[HOST]:[PORT:9100]",
   "ports": {
     "9100/tcp": 9100
@@ -25,13 +23,13 @@
   "host_pid": true,
   "apparmor": false,
   "options": {
-	"enable_basic_auth": false,
+	  "enable_basic_auth": false,
     "basic_auth_user": "prom",
-	"basic_auth_pass": "$2a$12$Azy3nrjebl.U17DLmpX57.cUUKzm/PX5thtAkf7xl/hUHSJrm4VkS"
+	  "basic_auth_pass": "$2a$12$Azy3nrjebl.U17DLmpX57.cUUKzm/PX5thtAkf7xl/hUHSJrm4VkS"
   },
   "schema": {
-	"enable_basic_auth": "bool",
+	  "enable_basic_auth": "bool",
     "basic_auth_user": "str",
-	"basic_auth_pass": "str"
+	  "basic_auth_pass": "str"
   }
 }

--- a/prometheus_node_exporter/rootfs/etc/services.d/node_exporter/finish
+++ b/prometheus_node_exporter/rootfs/etc/services.d/node_exporter/finish
@@ -6,4 +6,4 @@
 if { s6-test ${1} -ne 0 }
 if { s6-test ${1} -ne 256 }
 
-s6-svscanctl -t /var/run/s6/services
+/run/s6/basedir/bin/halt

--- a/prometheus_node_exporter/rootfs/etc/services.d/node_exporter/finish
+++ b/prometheus_node_exporter/rootfs/etc/services.d/node_exporter/finish
@@ -1,4 +1,4 @@
-#!/usr/bin/execlineb -S0
+#!/usr/bin/env bashio
 # ==============================================================================
 # Home Assistant Community Add-on: Prometheus Node Exporter
 # Take down the S6 supervision tree when Prometheus Node Exporter fails

--- a/prometheus_node_exporter/rootfs/etc/services.d/node_exporter/run
+++ b/prometheus_node_exporter/rootfs/etc/services.d/node_exporter/run
@@ -6,6 +6,4 @@
 bashio::log.info "Starting prometheus node exporter..."
 
 # Run Prometheus
-exec s6-setuidgid prometheus /usr/local/bin/node_exporter
-
-# --web.config=/etc/prometheus_node_exporter/node_exporter_web.yml
+exec s6-setuidgid prometheus /usr/local/bin/node_exporter --web.config=/etc/prometheus_node_exporter/node_exporter_web.yml

--- a/prometheus_node_exporter/rootfs/etc/services.d/node_exporter/run
+++ b/prometheus_node_exporter/rootfs/etc/services.d/node_exporter/run
@@ -6,4 +6,6 @@
 bashio::log.info "Starting prometheus node exporter..."
 
 # Run Prometheus
-exec s6-setuidgid prometheus /usr/local/bin/node_exporter --web.config=/etc/prometheus_node_exporter/node_exporter_web.yml
+exec s6-setuidgid prometheus /usr/local/bin/node_exporter
+
+# --web.config=/etc/prometheus_node_exporter/node_exporter_web.yml


### PR DESCRIPTION
Fixes #2 temporarily by switching to HACS base images, which are still on s6 v2.

In the long-term, s6 v3 is not compatible with the `host_pid` option. I need to either remove the `host_pid` usage (which will probably limit the metrics I can collect), or switch to stock alpine or debian as a base.

Will track issue [here](https://github.com/home-assistant/supervisor/issues/3642) and the [glances add-on](https://github.com/hassio-addons/addon-glances), which also uses `host_pid`.