### PR TITLE
Upgrade add-on base image to 12.2.0

### DIFF
--- a/prometheus_node_exporter/CHANGELOG.md
+++ b/prometheus_node_exporter/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [0.1.0] - 2022-07-11
+- Upgrade base image from `ghcr.io/hassio-addons/base/<arch>:11.1.2` to `12.2.0` (Alpine Linux 3.16), but also disable the s6 init system because of [this issue](https://github.com/home-assistant/supervisor/issues/3642)
+
 ## [0.0.7] - 2022-06-07
 - Upgrade base image from `ghcr.io/hassio-addons/base/<arch>:11.1.0` to `11.1.2` (this is the latest and last without s6 v3)
 

--- a/prometheus_node_exporter/Dockerfile
+++ b/prometheus_node_exporter/Dockerfile
@@ -23,3 +23,8 @@ RUN \
     && adduser -s /bin/false -D -H prometheus \
     && chown -R prometheus:prometheus /usr/local/bin/node_exporter \
     && rm -f -r /tmp/*
+
+# This add-on runs on the host pid namespace, making it impossible
+# to use S6-Overlay. Therefore the init system is disabled at this point.
+ENTRYPOINT []
+CMD ["/run.sh"]

--- a/prometheus_node_exporter/build.json
+++ b/prometheus_node_exporter/build.json
@@ -1,8 +1,8 @@
 {
   "build_from": {
-    "amd64": "ghcr.io/hassio-addons/base/amd64:11.1.2",
-    "aarch64": "ghcr.io/hassio-addons/base/aarch64:11.1.2",
-    "armv7": "ghcr.io/hassio-addons/base/armv7:11.1.2"
+    "amd64": "ghcr.io/hassio-addons/base/amd64:12.2.0",
+    "aarch64": "ghcr.io/hassio-addons/base/aarch64:12.2.0",
+    "armv7": "ghcr.io/hassio-addons/base/armv7:12.2.0"
   },
   "args": {
     "NODE_EXPORTER_VERSION": "1.3.1"

--- a/prometheus_node_exporter/config.json
+++ b/prometheus_node_exporter/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Prometheus Node Exporter",
-  "version": "0.0.7",
+  "version": "0.1.0",
   "slug": "prometheus_node_exporter",
   "description": "Prometheus node exporter for hardware and OS metrics",
   "url": "https://github.com/loganmarchione/hassos-addons/tree/main/prometheus_node_exporter",

--- a/prometheus_node_exporter/rootfs/bin/s6-nuke
+++ b/prometheus_node_exporter/rootfs/bin/s6-nuke
@@ -1,8 +1,0 @@
- #!/usr/bin/env bash
-# ==============================================================================
-# Home Assistant Community Add-on: Glances
-# This file turns s6-nuke into a NOOP to prevent total termination
-# of the host system since the add-on runs in the same PID namespace.
-# ==============================================================================
-echo "S6-NUKE: NOOP"
-exit 0

--- a/prometheus_node_exporter/rootfs/etc/cont-init.d/node_exporter.sh
+++ b/prometheus_node_exporter/rootfs/etc/cont-init.d/node_exporter.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/with-contenv bashio
+#!/usr/bin/env bashio
 # ==============================================================================
 # Home Assistant Community Add-on: Prometheus Node Exporter
 # Configures Prometheus Node Exporter
@@ -8,7 +8,7 @@ echo "${SUPERVISOR_TOKEN}" > '/run/home-assistant.token'
 
 # Even if the user isn't using these options, we're creating the web config file
 # This will allow us to append to the web config file as needed (based on variables)
-# Node_exporter will run with a blank web config file in the meantime
+# Prometheus Node Exporter will run with a blank web config file in the meantime
 
 web_config_dir=/etc/prometheus_node_exporter
 mkdir $web_config_dir

--- a/prometheus_node_exporter/rootfs/etc/services.d/node_exporter/finish
+++ b/prometheus_node_exporter/rootfs/etc/services.d/node_exporter/finish
@@ -1,9 +1,0 @@
-#!/usr/bin/env bashio
-# ==============================================================================
-# Home Assistant Community Add-on: Prometheus Node Exporter
-# Take down the S6 supervision tree when Prometheus Node Exporter fails
-# ==============================================================================
-if { s6-test ${1} -ne 0 }
-if { s6-test ${1} -ne 256 }
-
-/run/s6/basedir/bin/halt

--- a/prometheus_node_exporter/rootfs/etc/services.d/node_exporter/run
+++ b/prometheus_node_exporter/rootfs/etc/services.d/node_exporter/run
@@ -1,9 +1,9 @@
-#!/usr/bin/with-contenv bashio
+#!/usr/bin/env bashio
 # ==============================================================================
 # Home Assistant Community Add-on: Prometheus Node Exporter
 # Runs the Prometheus Node Exporter
 # ==============================================================================
-bashio::log.info "Starting prometheus node exporter..."
+bashio::log.info "Starting Prometheus Node Exporter..."
 
 # Run Prometheus
-exec s6-setuidgid prometheus /usr/local/bin/node_exporter --web.config=/etc/prometheus_node_exporter/node_exporter_web.yml
+exec /usr/local/bin/node_exporter --web.config=/etc/prometheus_node_exporter/node_exporter_web.yml

--- a/prometheus_node_exporter/rootfs/run.sh
+++ b/prometheus_node_exporter/rootfs/run.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bashio
+# ==============================================================================
+# Home Assistant Community Add-on: Prometheus Node Exporter
+# Runs the Prometheus Node Exporter
+# ==============================================================================
+#
+# WHAT IS THIS FILE?!
+#
+# The Prometheus Node Exporter add-on runs in the host PID namespace, therefore it cannot
+# use the regular S6-Overlay; hence this add-on uses a "old school" script
+# to run; with a couple of "hacks" to make it work.
+# ==============================================================================
+/etc/cont-init.d/node_exporter.sh
+
+# Start Prometheus Node Exporter
+exec /etc/services.d/node_exporter/run


### PR DESCRIPTION
- Upgrade add-on base image to 12.2.0
- Disable the s6 init system because of [this issue](https://github.com/home-assistant/supervisor/issues/3642)