### PR TITLE
Add support for command line extra arguments

### DIFF
--- a/prometheus_node_exporter/config.json
+++ b/prometheus_node_exporter/config.json
@@ -31,7 +31,8 @@
     "basic_auth_pass": "$2a$12$Azy3nrjebl.U17DLmpX57.cUUKzm/PX5thtAkf7xl/hUHSJrm4VkS",
     "enable_tls": false,
     "cert_file": "",
-    "cert_key": ""
+    "cert_key": "",
+    "cmdline_extra_args": ""
   },
   "schema": {
     "enable_basic_auth": "bool",
@@ -39,6 +40,7 @@
     "basic_auth_pass": "str",
     "enable_tls": "bool",
     "cert_file": "str",
-    "cert_key": "str"
+    "cert_key": "str",
+    "cmdline_extra_args": "str?"
   }
 }

--- a/prometheus_node_exporter/rootfs/etc/services.d/node_exporter/run
+++ b/prometheus_node_exporter/rootfs/etc/services.d/node_exporter/run
@@ -6,4 +6,4 @@
 bashio::log.info "Starting Prometheus Node Exporter..."
 
 # Run Prometheus
-exec /usr/local/bin/node_exporter --web.config.file=/config/prometheus_node_exporter/node_exporter_web.yml
+exec /usr/local/bin/node_exporter --web.config.file=/config/prometheus_node_exporter/node_exporter_web.yml $(bashio::config 'cmdline_extra_args' '')

--- a/prometheus_node_exporter/translations/en.yaml
+++ b/prometheus_node_exporter/translations/en.yaml
@@ -18,3 +18,6 @@ configuration:
   cert_key:
     name: Private key
     description: This is a /path/to/privkey.pem
+  cmdline_extra_args:
+    name: Command line extra arguments
+    description: Extra arguments to pass to the "node_exporter" command at startup (see https://github.com/prometheus/node_exporter/#installation-and-usage for more information)


### PR DESCRIPTION
This change introduces a new `cmdline_extra_args` option allowing users to pass extra arguments to the `node_exporter` command at startup.