### PR TITLE
publish image with github actions

### DIFF
--- a/.github/actions/check-ghcr/action.yml
+++ b/.github/actions/check-ghcr/action.yml
@@ -1,0 +1,29 @@
+name: "GHCR Checker"
+description: "check ghcr for existing container version"
+inputs:
+  configpath:
+    description: "path of the addon config to determine current version"
+    required: true
+  image:
+    description: "image to check (without ghcr.io/ prefix)"
+    required: true
+  token:
+    description: "token to use"
+    required: true
+outputs:
+  status:
+    description: "status code for image manifest"
+    value: ${{ steps.check.outputs.status }}
+runs:
+  using: "composite"
+  steps:
+    - shell: bash
+      id: version
+      run: |
+        echo "version=$(grep version ${{ inputs.configpath }}| awk -F: '{print $2}' | grep -Eo '[v0-9\.-]+')" >> "$GITHUB_OUTPUT"
+    - shell: bash
+      id: check
+      run: |
+        GHCR_TOKEN=$(echo ${{ inputs.token }} | base64)
+        STATUS=$(curl -H "Authorization: Bearer ${GHCR_TOKEN}" https://ghcr.io/v2/${{ inputs.image }}/manifests/${{ steps.version.outputs.version }} -o /dev/null -w "%{http_code}" -s)
+        echo "status=${STATUS}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/prometheus_node_exporter.yml
+++ b/.github/workflows/prometheus_node_exporter.yml
@@ -1,0 +1,35 @@
+name: "Publish Prometheus Node Exporter"
+
+on:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  publish:
+    name: Publish Prometheus Node Exporter Image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check Version
+        id: check
+        uses: ./.github/actions/check-ghcr
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          image: loganmarchione/hassos-addons/prometheusnodeexporter-aarch64
+          configpath: prometheus_node_exporter/config.json
+      - name: Publish
+        if: ${{ steps.check.outputs.status == '404' }}
+        uses: home-assistant/builder@master
+        with:
+          args: |
+            --aarch64 --amd64 --armv7 \
+            --target prometheus_node_exporter \
+            --docker-hub ghcr.io/loganmarchione/hassos-addons \
+            --image prometheusnodeexporter-{arch}

--- a/prometheus_node_exporter/README.md
+++ b/prometheus_node_exporter/README.md
@@ -86,7 +86,7 @@ WIP
 - [x] Add HTTP Basic Auth
 - [ ] Add abilty to enter plain-text password instead of bcyrpt-ed hash
 - [x] Add TLS
-- [ ] Per [this comment](https://community.home-assistant.io/t/hello-world-example-addon-from-developer-docs-stopped-working-s6-overlay-issue/421486/7), setup container images on a registry (DockerHub or GitHub) so that users aren't building the container with each install (would have prevented [this issue](https://github.com/loganmarchione/hassos-addons/issues/2))
+- [x] Per [this comment](https://community.home-assistant.io/t/hello-world-example-addon-from-developer-docs-stopped-working-s6-overlay-issue/421486/7), setup container images on a registry (DockerHub or GitHub) so that users aren't building the container with each install (would have prevented [this issue](https://github.com/loganmarchione/hassos-addons/issues/2))
 - [x] Investigate CI/CD for this repo, specifically [this](https://github.com/home-assistant/actions) and [this](https://github.com/hassio-addons/addon-glances/blob/main/.github/workflows/ci.yaml) as an example
 - [ ] Investigate dropping API access (e.g., `hassio_api`, `homeassistant_api`, `auth_api`) in order to get my rating up
 

--- a/prometheus_node_exporter/config.json
+++ b/prometheus_node_exporter/config.json
@@ -1,9 +1,10 @@
 {
   "name": "Prometheus Node Exporter",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "slug": "prometheus_node_exporter",
   "description": "Prometheus node exporter for hardware and OS metrics",
   "url": "https://github.com/loganmarchione/hassos-addons/tree/main/prometheus_node_exporter",
+  "image": "ghcr.io/loganmarchione/hassos-addons/prometheusnodeexporter-{arch}",
   "arch": ["amd64", "aarch64", "armv7"],
   "startup": "services",
   "init": false,


### PR DESCRIPTION
setup GitHub actions to publish the image. if I understand correctly, the backups include the image when it's not published, so by publishing the image, backup size should be reduced